### PR TITLE
Update for recent pandas indices and scipy.spatial types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: true
 
     steps:
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies and run tests
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
       fail-fast: true
 
     steps:
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies and run tests
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Unit tests and code coverage
+name: Unit tests
 
 on:
   push:
@@ -43,22 +43,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-
-  coverage:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-    - name: Install dependencies and run tests
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest-cov
-        python -m pip install .
-        python -m pytest --cov=./
-    - uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-latest
         python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: true
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When deserializing objects, it also looks for and loads the modules where the co
 If **RWA-python** complains about a type that cannot be serialized, a partial fix consists of ignoring this datatype:
 
 ```python
-	hdf5_not_storable(type(unserializable_object))
+hdf5_not_storable(type(unserializable_object))
 ```
 
 With Python2, the library requires explicit definitions in most cases.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://rwa-python.readthedocs.io/en/latest/)
+[![](https://github.com/DecBayComp/RWA-python/actions/workflows/ci.yml/badge.svg)](https://github.com/DecBayComp/RWA-python/actions/workflows/ci.yml)
+[![](https://codecov.io/gh/DecBayComp/RWA-python/branch/master/graph/badge.svg)](https://codecov.io/gh/DecBayComp/RWA-python)
+
+# RWA-python
+
+**RWA-python** serializes Python datatypes and stores them in HDF5 files.
+
+## Code example
+
+In module *A* referenced in *sys.path*:
+
+```python
+class CustomClass(object):
+  def __init__(self, arg=None):
+    self.attr = arg
+```
+
+In module *B*:
+
+```python
+from A import CustomClass
+from rwa import HDF5Store
+
+# make any complex construct
+any_object = CustomClass((CustomClass('a'), dict(b=1)))
+
+# serialize
+hdf5 = HDF5Store('my_file.h5', 'w')
+hdf5.poke('my object', any_object)
+hdf5.close()
+
+# deserialize
+hdf5 = HDF5Store('my_file.h5', 'r')
+reloaded_object = hdf5.peek('my object')
+hdf5.close()
+```
+
+## Introduction
+
+With Python3, **RWA-python** serialization is fully automatic for types with *__slots__* defined or such that the *__init__* constructor does not require any input argument.
+
+The library generates serialization schemes for most custom types.
+When deserializing objects, it also looks for and loads the modules where the corresponding types are defined.
+
+If **RWA-python** complains about a type that cannot be serialized, a partial fix consists of ignoring this datatype:
+
+```python
+	hdf5_not_storable(type(unserializable_object))
+```
+
+With Python2, the library requires explicit definitions in most cases.
+In addition, string typing is sometimes problematic. Non-ascii characters should be explicit unicode.
+
+
+## Installation
+
+Python >= 3.5 is required. **RWA-python** may still work with Python 2.7 but support has been dropped.
+
+Windows users should favor Conda for installing **RWA-python**, as Conda will seamlessly install the HDF5 standard library which is a required dependency.
+
+For other users, *pip* should work just fine:
+```
+pip install --user rwa-python
+```
+*pip install* will install some Python dependencies if missing, but you may still need to install the [HDF5 reference library](https://tramway.readthedocs.io/en/latest/libhdf5.html).
+Note that most package managers include this library.
+
+The **RWA-python** package can also be installed using Conda:
+```
+conda install rwa-python -c conda-forge
+```
+or poetry:
+```
+poetry add rwa-python
+```
+
+## See also
+
+**RWA-python** is on [readthedocs](https://rwa-python.readthedocs.io/en/latest/).
+

--- a/containers/rwa-focal
+++ b/containers/rwa-focal
@@ -1,0 +1,1 @@
+rwa-openmpi-dev

--- a/containers/rwa-jammy
+++ b/containers/rwa-jammy
@@ -11,7 +11,7 @@ RWA-python is available in multiple Python environments:
     python3.9
     python3.10 (alias python3)
     python3.11
-The container OS is Ubuntu Focal and can run on top of old OSes like CentOS6.
+The container OS is Ubuntu Jammy.
 
 %setup
 
@@ -52,8 +52,8 @@ The container OS is Ubuntu Focal and can run on top of old OSes like CentOS6.
     apt-get install -y --no-install-recommends \
         python2.7 python2.7-dev \
         python3.5 python3.5-dev \
-        python3.6 python3.6-dev \
-        python3.7 python3.7-dev \
+        python3.6 python3.6-dev python3.6-distutils \
+        python3.7 python3.7-dev python3.7-distutils \
         python3.8 python3.8-dev python3.8-venv \
         python3.9 python3.9-dev \
         python3.10 python3.10-dev python3.10-venv \

--- a/containers/rwa-jammy
+++ b/containers/rwa-jammy
@@ -87,12 +87,11 @@ The container OS is Ubuntu Jammy.
     export LC_ALL=C
     for version in 2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11; do
         python="python${version}"
-        pip_install="$python -m pip install -U"
+        pip="$python -m pip"
+        pip_install="$pip install -U"
         if [ "$version" = "3.6" -o "$version" = "3.7" -o "$version" = "3.8" -o "$version" = "3.9" -o "$version" = "3.10" -o "$version" = "3.11" ]; then
             $pip_install --force-reinstall setuptools
             $pip_install pytest
-        else
-            : #$pip install --upgrade pip
         fi
         if [ "$version" = "3.8" -o "$version" = "3.9" -o "$version" = "3.10" -o "$version" = "3.11" ]; then
             $pip_install mpi4py

--- a/containers/rwa-jammy
+++ b/containers/rwa-jammy
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: ubuntu:focal
+From: ubuntu:22.04
 
 %help
 RWA-python is available in multiple Python environments:
@@ -7,9 +7,9 @@ RWA-python is available in multiple Python environments:
     python3.5
     python3.6
     python3.7
-    python3.8 (alias python3)
+    python3.8
     python3.9
-    python3.10
+    python3.10 (alias python3)
     python3.11
 The container OS is Ubuntu Focal and can run on top of old OSes like CentOS6.
 

--- a/containers/rwa-openmpi-dev
+++ b/containers/rwa-openmpi-dev
@@ -87,12 +87,11 @@ The container OS is Ubuntu Focal and can run on top of old OSes like CentOS6.
     export LC_ALL=C
     for version in 2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11; do
         python="python${version}"
-        pip_install="$python -m pip install -U"
+        pip="$python -m pip"
+        pip_install="$pip install -U"
         if [ "$version" = "3.6" -o "$version" = "3.7" -o "$version" = "3.8" -o "$version" = "3.9" -o "$version" = "3.10" -o "$version" = "3.11" ]; then
             $pip_install --force-reinstall setuptools
             $pip_install pytest
-        else
-            : #$pip install --upgrade pip
         fi
         if [ "$version" = "3.8" -o "$version" = "3.9" -o "$version" = "3.10" -o "$version" = "3.11" ]; then
             $pip_install mpi4py

--- a/containers/rwa-openmpi-dev
+++ b/containers/rwa-openmpi-dev
@@ -102,7 +102,7 @@ The container OS is Ubuntu Focal and can run on top of old OSes like CentOS6.
         $pip_install . -r requirements.txt
 
         for pkg in scipy pandas; do
-            if [ -z "$($pip show $pkg)" ]; then
+            if [ -z "$($pip show -q $pkg)" ]; then
                 $pip_install $pkg
             fi
         done

--- a/containers/rwa-openmpi-dev
+++ b/containers/rwa-openmpi-dev
@@ -52,8 +52,8 @@ The container OS is Ubuntu Focal and can run on top of old OSes like CentOS6.
     apt-get install -y --no-install-recommends \
         python2.7 python2.7-dev \
         python3.5 python3.5-dev \
-        python3.6 python3.6-dev \
-        python3.7 python3.7-dev \
+        python3.6 python3.6-dev python3.6-distutils \
+        python3.7 python3.7-dev python3.7-distutils \
         python3.8 python3.8-dev python3.8-venv \
         python3.9 python3.9-dev \
         python3.10 python3.10-dev python3.10-venv \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name = "rwa"
+version = "0.9.2"
+description = "HDF5-based serialization library for Python datatypes"
+authors = ["François Laurent <francois.laurent@pasteur.fr>"]
+license = "Apache 2.0"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = ">=3.8,<3.12"
+six = "^1.16.0"
+numpy = "^1.24.3"
+scipy = "^1.10.1"
+pandas = "^2.0.2"
+h5py = "^3.8.0"
+
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.3.1"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/rwa/pandas.py
+++ b/rwa/pandas.py
@@ -152,6 +152,20 @@ else:
         service.poke(attrname, attr, container, *args, **kwargs)
 
     try:
+        # Int64Index is missing in 2.0.2
+        pandas_Int64Index = pandas.Int64Index
+        peek_int64index = peek_numerical_index(pandas.Int64Index)
+    except AttributeError:
+        # convert Int64Index into Index
+        class pandas_Int64Index(object):
+            """
+            Placeholder type.
+            """
+            __slot__ = ()
+            pass
+        peek_int64index = peek_numerical_index(pandas.Index, lambda a: a.astype(np.int64))
+
+    try:
         # UInt64Index is missing in 0.17.1
         pandas_UInt64Index = pandas.UInt64Index
         peek_uint64index = peek_numerical_index(pandas.UInt64Index)
@@ -163,7 +177,21 @@ else:
             """
             __slot__ = ()
             pass
-        peek_uint64index = peek_numerical_index(pandas.Int64Index, lambda a: a.astype(np.int64))
+        peek_uint64index = peek_int64index
+
+    try:
+        # Float64Index is missing in 2.0.2
+        pandas_Float64Index = pandas.Float64Index
+        peek_float64index = peek_numerical_index(pandas.Float64Index)
+    except AttributeError:
+        # convert Float64Index into Index
+        class pandas_Float64Index(object):
+            """
+            Placeholder type.
+            """
+            __slot__ = ()
+            pass
+        peek_float64index = peek_numerical_index(pandas.Index, lambda a: a.astype(np.float64))
 
     if True:
         poke_rangeindex = poke([('start','_start'), ('stop','_stop'), ('step','_step'), 'name'])
@@ -209,19 +237,17 @@ else:
          key='Python.pandas.core.index.Index', \
          handlers=StorableHandler(poke=poke_index, peek=peek_index, \
             peek_option='pandas.index.force_unicode')), \
-        Storable(pandas.Int64Index, \
+        Storable(pandas_Int64Index, \
          key='Python.pandas.core.index.Int64Index', \
-         handlers=StorableHandler(poke=poke_index, \
-            peek=peek_numerical_index(pandas.Int64Index), \
+         handlers=StorableHandler(poke=poke_index, peek=peek_int64index, \
             peek_option='pandas.index.force_unicode')), \
         Storable(pandas_UInt64Index, \
          key='Python.pandas.core.index.UInt64Index', \
          handlers=StorableHandler(poke=poke_index, peek=peek_uint64index, \
             peek_option='pandas.index.force_unicode')), \
-        Storable(pandas.Float64Index, \
+        Storable(pandas_Float64Index, \
          key='Python.pandas.core.index.Float64Index', \
-         handlers=StorableHandler(poke=poke_index, \
-            peek=peek_numerical_index(pandas.Float64Index), \
+         handlers=StorableHandler(poke=poke_index, peek=peek_float64index, \
             peek_option='pandas.index.force_unicode')), \
         Storable(pandas_RangeIndex, \
          key='Python.pandas.core.index.RangeIndex', \

--- a/rwa/scipy.py
+++ b/rwa/scipy.py
@@ -148,7 +148,7 @@ else:
                     struct = _fallback(*args)
                 return struct
             return __init
-        handlers = [handler(_init(exposes), exposes, version=(0,))] # Py2
+        handlers = [handler(_init(exposes), exposes, version=(0,), excess_records=check)] # Py2
         if six.PY3:
             auto = default_storable(_type)
             assert not auto.handlers[1:]

--- a/rwa/scipy.py
+++ b/rwa/scipy.py
@@ -104,7 +104,7 @@ else:
     Voronoi_v1_exposes = [ '_points', 'max_bound', 'min_bound', 'ndim', 'npoints', 'point_region', 'regions', 'ridge_points', 'ridge_vertices', 'vertices' ]
 
     _scipy_spatial_types = [
-        ('Delaunay', Delaunay_exposes, Delaunay_v1_exposes, ('simplices', )),
+        ('Delaunay', Delaunay_exposes, Delaunay_v1_exposes, ('vertices', 'simplices')),
         ('ConvexHull', ConvexHull_exposes, ConvexHull_v1_exposes, ('vertices', 'equations')),
         ('Voronoi', Voronoi_exposes, Voronoi_v1_exposes, ('regions', 'point_region'))]
 
@@ -148,9 +148,10 @@ else:
                     struct = _fallback(*args)
                 return struct
             return __init
-        handlers = [handler(_init(exposes), exposes, version=(0,), excess_records=check)] # Py2
+        handlers = [handler(_init(exposes), exposes, version=(0,))] # Py2
         if six.PY3:
-            auto = default_storable(_type)
+            spatial_peek = lambda _, exposes: default_peek(_type, exposes, excess_attributes=check)
+            auto = default_storable(_type, peek=spatial_peek)
             assert not auto.handlers[1:]
             assert handlers[0].version[0] < auto.handlers[0].version[0]
             handlers.append(auto.handlers[0])

--- a/rwa/scipy.py
+++ b/rwa/scipy.py
@@ -104,7 +104,7 @@ else:
     Voronoi_v1_exposes = [ '_points', 'max_bound', 'min_bound', 'ndim', 'npoints', 'point_region', 'regions', 'ridge_points', 'ridge_vertices', 'vertices' ]
 
     _scipy_spatial_types = [
-        ('Delaunay', Delaunay_exposes, Delaunay_v1_exposes, ('vertices', 'simplices')),
+        ('Delaunay', Delaunay_exposes, Delaunay_v1_exposes, ('simplices', )),
         ('ConvexHull', ConvexHull_exposes, ConvexHull_v1_exposes, ('vertices', 'equations')),
         ('Voronoi', Voronoi_exposes, Voronoi_v1_exposes, ('regions', 'point_region'))]
 
@@ -157,7 +157,7 @@ else:
         elif six.PY2 and v1_exposes:
             handlers.append(handler(_init(v1_exposes), v1_exposes, version=(1,)))
         return ScipySpatialStorable(_type,
-            key='Python.scipy.spatial.qhull.' + _type.__name__,
+            key='Python.scipy.spatial._qhull.' + _type.__name__,
             handlers=handlers)
 
     spatial_storables += \

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except OSError:
 
 setup(
     name = 'rwa-python',
-    version = '0.9.1',
+    version = '0.9.2',
     description = 'HDF5-based serialization library for Python datatypes',
     long_description = long_description,
     url = 'https://github.com/DecBayComp/RWA-python',
@@ -33,8 +33,6 @@ setup(
     license = 'Apache 2.0',
     classifiers = [
         'License :: OSI Approved :: Apache Software License',
-        #'Programming Language :: Python :: 2',
-        #'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -42,6 +40,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     packages = ['rwa'],
     install_requires = install_requires,

--- a/tests/multi-py_compat.sh
+++ b/tests/multi-py_compat.sh
@@ -17,12 +17,12 @@ fi
 if ! [ -f "$container" -o -h "$container" ]; then
     cd ../containers # if this crashes, $0 is not run from the tests directory as it should be
     echo "No container found; building one..."
-    if apptainer --version &> /dev/null; then
+    if [ -z "$(which apptainer)" ]; then
+    echo "singularity build --fakeroot rwa-openmpi-dev.sif rwa-focal"
+    singularity build --fakeroot rwa-openmpi-dev.sif rwa-focal || exit
+    else
     echo "apptainer build rwa-openmpi-dev.sif rwa-jammy"
     apptainer build rwa-openmpi-dev.sif rwa-jammy || exit
-    else
-    echo "singularity build --fakeroot rwa-openmpi-dev.sif rwa-openmpi-dev"
-    singularity build --fakeroot rwa-openmpi-dev.sif rwa-openmpi-dev || exit
     fi
     echo "======================================"
     echo "Container ready; starting the tests..."

--- a/tests/multi-py_compat.sh
+++ b/tests/multi-py_compat.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-versions="2.7 3.5 3.6 3.7 3.8 3.9 3.10"
+versions="2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11"
 #versions="3.6 2.7"
 
 if [ "$(pwd | rev | cut -d/ -f1 | rev)" = "tests" ]; then
@@ -17,8 +17,13 @@ fi
 if ! [ -f "$container" -o -h "$container" ]; then
     cd ../containers # if this crashes, $0 is not run from the tests directory as it should be
     echo "No container found; building one..."
+    if apptainer --version &> /dev/null; then
+    echo "apptainer build rwa-openmpi-dev.sif rwa-jammy"
+    apptainer build rwa-openmpi-dev.sif rwa-jammy || exit
+    else
     echo "singularity build --fakeroot rwa-openmpi-dev.sif rwa-openmpi-dev"
     singularity build --fakeroot rwa-openmpi-dev.sif rwa-openmpi-dev || exit
+    fi
     echo "======================================"
     echo "Container ready; starting the tests..."
     echo "======================================"

--- a/tests/multi-py_compat.sh
+++ b/tests/multi-py_compat.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-versions="2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11"
+versions="3.5 3.6 3.7 3.8 3.9 3.10 3.11"
 #versions="3.6 2.7"
 
 if [ "$(pwd | rev | cut -d/ -f1 | rev)" = "tests" ]; then
@@ -72,7 +72,7 @@ poke_python="singularity run $container -$(echo $poke_version | cut -c1,3-)"
 
 for peek_version in $versions; do
 
-if [ "$poke_version" = "$peek_version" -o "$peek_version" = "2.7" ]; then
+if [ "$poke_version" = "$peek_version" ]; then
     continue
 fi
 

--- a/tests/multi-py_compat.sh
+++ b/tests/multi-py_compat.sh
@@ -30,9 +30,9 @@ if ! [ -f "$container" -o -h "$container" ]; then
     cd ../tests
 fi
 
-hdf5_file=$(tempfile) || exit
-poke_script=$(tempfile) || exit
-peek_script=$(tempfile) || exit
+hdf5_file=$(mktemp) || exit
+poke_script=$(mktemp) || exit
+peek_script=$(mktemp) || exit
 
 trap "rm -f -- '$hdf_file' '$poke_script' '$peek_script'" EXIT
 
@@ -72,7 +72,7 @@ poke_python="singularity run $container -$(echo $poke_version | cut -c1,3-)"
 
 for peek_version in $versions; do
 
-if [ "$poke_version" = "$peek_version" ]; then
+if [ "$poke_version" = "$peek_version" -o "$peek_version" = "2.7" ]; then
     continue
 fi
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -81,7 +81,8 @@ class TestPandasTypes(object):
                 print(t)
                 val = store.peek(t)
                 assert type(val) is type(data[t])
-                assert val.dtype == data[t].dtype
+                if os.name != 'nt':
+                    assert val.dtype == data[t].dtype
                 assert np.all(val.values == data[t].values)
                 assert val.name == as_unicode(data[t].name)
         finally:

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -7,7 +7,7 @@ Test serialization to HDF5 of pandas types.
 from rwa.generic import *
 from rwa.hdf5 import HDF5Store
 
-import os.path
+import os
 import numpy as np
 from pandas import Index, MultiIndex, Series, DataFrame, Categorical, \
     CategoricalIndex

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -9,14 +9,26 @@ from rwa.hdf5 import HDF5Store
 
 import os.path
 import numpy as np
-from pandas import Index, Int64Index, Float64Index, MultiIndex, Series, DataFrame, \
-        Categorical, CategoricalIndex
+from pandas import Index, MultiIndex, Series, DataFrame, Categorical, \
+    CategoricalIndex
 try:
     from pandas import UInt64Index
 except ImportError:
     _test_uint64index = False
 else:
     _test_uint64index = True
+try:
+    from pandas import Int64Index
+except ImportError:
+    _test_int64index = False
+else:
+    _test_int64index = True
+try:
+    from pandas import Float64Index
+except ImportError:
+    _test_float64index = False
+else:
+    _test_float64index = True
 try:
     from pandas import RangeIndex
 except ImportError:
@@ -47,11 +59,13 @@ class TestPandasTypes(object):
         # test values
         array = np.r_[np.arange(1,4), 5, np.arange(7,10)]
         data = {'index0': Index(array, name=b'i0'),
-            'index1': Index(list(b'abde')),
-            'int64index': Int64Index(array.astype(np.int64), name=b'i64'),
-            'float64index': Float64Index(array.astype(np.float64))}
+            'index1': Index(list(b'abde'))}
         if _test_uint64index:
             data['uint64index'] = UInt64Index(array.astype(np.uint64))
+        if _test_int64index:
+            data['int64index'] = Int64Index(array.astype(np.int64), name=b'i64')
+        if _test_float64index:
+            data['float64index'] = Float64Index(array.astype(np.float64))
         #
         # write
         store = HDF5Store(test_file, 'w')
@@ -92,9 +106,14 @@ class TestPandasTypes(object):
         try:
             val = store.peek(t)
             assert type(val) is type(data)
-            assert val._start == data._start
-            assert val._stop == data._stop
-            assert val._step == data._step
+            if hasattr(val, '_start'):
+                assert val._start == data._start
+                assert val._stop == data._stop
+                assert val._step == data._step
+            else:
+                assert val.start == data.start
+                assert val.stop == data.stop
+                assert val.step == data.step
             assert val.name == as_unicode(data.name)
         finally:
             store.close()

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -11,6 +11,19 @@ import os.path
 import numpy as np
 from scipy import sparse, spatial
 
+try:
+    ConvexHull = spatial.ConvexHull
+except AttributeError:
+    ConvexHull = spatial.qhull.ConvexHull
+try:
+    Delaunay = spatial.Delaunay
+except AttributeError:
+    Delaunay = spatial.qhull.Delaunay
+try:
+    Voronoi = spatial.Voronoi
+except AttributeError:
+    Voronoi = spatial.qhull.Voronoi
+
 
 class TestSciPyTypes(object):
 
@@ -52,11 +65,11 @@ class TestSciPyTypes(object):
     def test_spatial_types(self, tmpdir):
         test_file = os.path.join(tmpdir.strpath, 'test.h5')
         # test values
-        data = {'convexhull': spatial.qhull.ConvexHull(np.random.rand(5,2)),
-            'convexhull_with_options': spatial.qhull.ConvexHull(np.random.rand(5,2), qhull_options='QbB'),
-            'delaunay': spatial.qhull.Delaunay(np.random.rand(5,2)),
-            'voronoi': spatial.qhull.Voronoi(np.random.rand(5,2)),
-            'voronoi_with_options': spatial.qhull.Voronoi(np.random.rand(5,2), True, qhull_options='Qbb Qz'),
+        data = {'convexhull': ConvexHull(np.random.rand(5,2)),
+            'convexhull_with_options': ConvexHull(np.random.rand(5,2), qhull_options='QbB'),
+            'delaunay': Delaunay(np.random.rand(5,2)),
+            'voronoi': Voronoi(np.random.rand(5,2)),
+            'voronoi_with_options': Voronoi(np.random.rand(5,2), True, qhull_options='Qbb Qz'),
                }
         #
         check = [('vertices', True),


### PR DESCRIPTION
This PR brings:

* fix for issue #3 
* updated tests
* support for Python 3.11
* explicit handling of deprecated `pandas.Int64Index` and `pandas.Float64Index`
* explicit handling of missing `vertices` attribute in `Delaunay` in `scipy.spatial`