### PR TITLE
prepare conda build with poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rwa-python"
-version = "0.9.4"
+version = "0.9.5"
 description = "HDF5-based serialization library for Python datatypes"
 authors = ["François Laurent <francois.laurent@pasteur.fr>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [tool.poetry]
-name = "rwa"
+name = "rwa-python"
 version = "0.9.4"
 description = "HDF5-based serialization library for Python datatypes"
 authors = ["François Laurent <francois.laurent@pasteur.fr>"]
 license = "Apache 2.0"
 readme = "README.md"
+packages = [{ include="rwa", from="." }]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{ include="rwa", from="." }]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.14"
+python = ">=3.8,<4.0"
 six = "^1.16.0"
 numpy = ">=0"
 scipy = ">=0"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except OSError:
 
 setup(
     name = 'rwa-python',
-    version = '0.9.4',
+    version = '0.9.5',
     description = 'HDF5-based serialization library for Python datatypes',
     long_description = long_description,
     url = 'https://github.com/DecBayComp/RWA-python',


### PR DESCRIPTION
Conda fails to build RWA-python because of missing setuptools for some versions of Python. Let us try with poetry instead.